### PR TITLE
Increase timeout to 1.5 seconds

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -373,7 +373,7 @@ sendHttpRequest(HTTP_ENDPOINT, (statusCode, headers, body) => {
   } else {
     data.gtmOnSuccess();
   }
-}, {headers: {'content-type': 'application/json'}, method: 'POST', timeout: 1000}, JSON.stringify(postBody));
+}, {headers: {'content-type': 'application/json'}, method: 'POST', timeout: 1500}, JSON.stringify(postBody));
 
 
 ___SERVER_PERMISSIONS___


### PR DESCRIPTION
When using the default timeout setting, up to 10% of requests to Amplitude tracking servers that happen within a very short amount of time can return with a `-1` status code.  Increasing the timeout to `1500` ms from `1000` ms resolved this issue.

More details about the issue can be found in [Amplitude's community post](https://community.amplitude.com/product-updates/amplitude-google-tag-manager-gtm-server-side-template-1057) on this topic, under the comment section.

This fix addresses issue #2 