### PR TITLE
Clearing undefined and null values from payload, added support to set the timestamp client side, increased api timeout to 5 seconds

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,8 +2,6 @@ homepage: "https://www.amplitude.com/"
 documentation: "https://developers.amplitude.com/docs/http-api-v2"
 versions:
   # Latest version
-  - sha: xxx
-    changeNotes: Clearing undefined and null values from payload, added support to set the timestamp client side, increased api timeout to 5 seconds.
   - sha: e92b42d40ef51178d9bf14909e328eee746c6919
     changeNotes: Add option to automatically track UTM parameters as user properties.
   - sha: 0d97a1f33383400cad024de6a5d98af0b37e9cad

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,8 @@ homepage: "https://www.amplitude.com/"
 documentation: "https://developers.amplitude.com/docs/http-api-v2"
 versions:
   # Latest version
+  - sha: xxx
+    changeNotes: Clearing undefined and null values from payload, added support to set the timestamp client side, increased api timeout to 5 seconds.
   - sha: e92b42d40ef51178d9bf14909e328eee746c6919
     changeNotes: Add option to automatically track UTM parameters as user properties.
   - sha: 0d97a1f33383400cad024de6a5d98af0b37e9cad

--- a/source.js
+++ b/source.js
@@ -1,0 +1,116 @@
+// Enter your template code here.
+const getEventData = require('getEventData');
+const getRemoteAddress = require('getRemoteAddress');
+const getTimestampMillis = require('getTimestampMillis');
+const JSON = require('JSON');
+const log = require('logToConsole');
+const makeInteger = require('makeInteger');
+const makeTableMap = require('makeTableMap');
+const parseUrl = require('parseUrl');
+const sendHttpRequest = require('sendHttpRequest');
+
+const HTTP_ENDPOINT = data.euServer ? 'https://api.eu.amplitude.com/2/httpapi' : 'https://api2.amplitude.com/2/httpapi';
+const GA4_USER_PREFIX = 'x-ga-mp2-user_properties.';
+const LOG_PREFIX = '[Amplitude] ';
+
+const apiKey = data.apiKey;
+const userIp = data.hideIp ? '$remote' : getRemoteAddress();
+const userId = getEventData('user_id') || getEventData(GA4_USER_PREFIX + 'user_id') || undefined;
+const deviceId = getEventData('client_id');
+const sessionId = makeInteger(getEventData('ga_session_id') + '000');
+const timestamp = getEventData('timestamp') || getTimestampMillis();
+const eventName = getEventData('event_name');
+const newEventProperties = data.newEventProperties && data.newEventProperties.length ? makeTableMap(data.newEventProperties, 'key', 'value') : {};
+const newUserProperties = data.newUserProperties && data.newUserProperties.length ? makeTableMap(data.newUserProperties, 'key', 'value') : {};
+const additionalProperties = data.additionalProperties && data.additionalProperties.length ? makeTableMap(data.additionalProperties, 'key', 'value') : {};
+
+const logAmplitude = msg => {
+  log(LOG_PREFIX + msg);
+};
+
+const mergeObj = (fromObj, toObj) => {
+  for (let key in fromObj) {
+    if (fromObj.hasOwnProperty(key) && fromObj[key] !== null && fromObj[key] !== undefined) {
+      toObj[key] = fromObj[key];
+    }
+  }
+  return toObj;
+};
+
+const getEventProps = () => {
+  const props = {};
+  if (data.eventProps && data.eventProps.length) {
+    data.eventProps.forEach(p => {
+      if (getEventData(p.key)) props[(p.mapKey || p.key)] = getEventData(p.key);
+    });
+  }
+  return mergeObj(newEventProperties, props);
+};
+
+const getUserProps = () => {
+  const props = {};
+  // Automatically collect UTMs
+  if (data.trackUtms) {
+    const parsedUrl = parseUrl(getEventData('page_location')) || {searchParams: {}};
+    props.utm_source = parsedUrl.searchParams.utm_source;
+    props.utm_medium = parsedUrl.searchParams.utm_medium;
+    props.utm_campaign = parsedUrl.searchParams.utm_campaign;
+    props.utm_term = parsedUrl.searchParams.utm_term;
+    props.utm_content = parsedUrl.searchParams.utm_content;
+  }
+  if (data.userProps && data.userProps.length) {
+    data.userProps.forEach(p => {
+      if (getEventData(p.key)) props[(p.mapKey || p.key)] = getEventData(p.key);
+    });
+  }
+  return mergeObj(newUserProperties, props);
+};
+
+const parseEventType = eventName => {
+  let eventType = data.blockIfNoMap ? null : eventName;
+  if (data.eventName && data.eventName.length) {
+    data.eventName.forEach(en => {
+      if (en.eventName === eventName) eventType = en.eventType;
+    });
+  }
+  return eventType;
+};
+
+const eventType = parseEventType(eventName);
+
+if (!eventType) {
+  logAmplitude('No event name match, aborting event dispatch.');
+  return data.gtmOnSuccess();
+}
+
+const baseEvent = {
+  device_id: deviceId,
+  event_type: eventType,
+  time: timestamp,
+  event_properties: getEventProps(),
+  user_properties: getUserProps(),
+  ip: userIp,
+  session_id: sessionId,
+  insert_id: deviceId + eventName + timestamp
+};
+
+if (userId) baseEvent.user_id = userId;
+
+// Merge final event from base event and additional properties. The latter overwrites.
+const finalEvent = mergeObj(additionalProperties, baseEvent);
+
+// Add library signature
+finalEvent.library = 'S-GTM';
+
+const postBody = {
+  api_key: apiKey,
+  events: [finalEvent]
+}; 
+
+sendHttpRequest(HTTP_ENDPOINT, (statusCode, headers, body) => {
+  if (statusCode >= 400) {
+    data.gtmOnFailure();
+  } else {
+    data.gtmOnSuccess();
+  }
+}, {headers: {'content-type': 'application/json'}, method: 'POST', timeout: 5000}, JSON.stringify(postBody));

--- a/template.tpl
+++ b/template.tpl
@@ -278,7 +278,7 @@ const userIp = data.hideIp ? '$remote' : getRemoteAddress();
 const userId = getEventData('user_id') || getEventData(GA4_USER_PREFIX + 'user_id') || undefined;
 const deviceId = getEventData('client_id');
 const sessionId = makeInteger(getEventData('ga_session_id') + '000');
-const timestamp = getTimestampMillis();
+const timestamp = getEventData('timestamp') || getTimestampMillis();
 const eventName = getEventData('event_name');
 const newEventProperties = data.newEventProperties && data.newEventProperties.length ? makeTableMap(data.newEventProperties, 'key', 'value') : {};
 const newUserProperties = data.newUserProperties && data.newUserProperties.length ? makeTableMap(data.newUserProperties, 'key', 'value') : {};
@@ -290,7 +290,7 @@ const logAmplitude = msg => {
 
 const mergeObj = (fromObj, toObj) => {
   for (let key in fromObj) {
-    if (fromObj.hasOwnProperty(key)) {
+    if (fromObj.hasOwnProperty(key) && fromObj[key] !== null && fromObj[key] !== undefined) {
       toObj[key] = fromObj[key];
     }
   }
@@ -373,7 +373,7 @@ sendHttpRequest(HTTP_ENDPOINT, (statusCode, headers, body) => {
   } else {
     data.gtmOnSuccess();
   }
-}, {headers: {'content-type': 'application/json'}, method: 'POST', timeout: 1000}, JSON.stringify(postBody));
+}, {headers: {'content-type': 'application/json'}, method: 'POST', timeout: 5000}, JSON.stringify(postBody));
 
 
 ___SERVER_PERMISSIONS___


### PR DESCRIPTION
Hello :)
I just created a pull request for changes which we are using in our sGTM instance which might be quite relevant for other Amplitude users as well:

1. I added support to set the timestamp client side using the event data key "timestamp". If this is set, it will have priority and the timestamp would not be set server side on sGTM.
2. Null and undefined values were not cleaned yet from the payload. I am not sure if this would be required to configure through a template field but I guess usually it is not wanted to track null or undefined values.
3. The timout for the HTTP API of 1 seconds seemed to be a bit risky. We increased it to 5 seconds.

Let me know what you think about the changes. If required, I could make some of the options dynamically configurable through template fields.

Regards
Florian