### PR TITLE
Use ip_override from event data to set IP & catch failed requests to avoid ssgtm Crashloops

### DIFF
--- a/source.js
+++ b/source.js
@@ -122,7 +122,7 @@ sendHttpRequest(
     return data.gtmOnFailure();
   }
   return data.gtmOnSuccess();
-}, (rejectedValue) => {
-  logAmplitude('Request failed with ' + JSON.stringify(rejectedValue));
+}).catch((error) => {
+  logAmplitude('Request failed with ' + JSON.stringify(error));
   return data.gtmOnFailure();
 });

--- a/source.js
+++ b/source.js
@@ -14,7 +14,7 @@ const GA4_USER_PREFIX = 'x-ga-mp2-user_properties.';
 const LOG_PREFIX = '[Amplitude] ';
 
 const apiKey = data.apiKey;
-const userIp = data.hideIp ? '$remote' : getRemoteAddress();
+const userIp = data.hideIp ? '$remote' : (getEventData('ip_override') || getRemoteAddress());
 const userId = getEventData('user_id') || getEventData(GA4_USER_PREFIX + 'user_id') || undefined;
 const deviceId = getEventData('client_id');
 const sessionId = makeInteger(getEventData('ga_session_id') + '000');

--- a/source.js
+++ b/source.js
@@ -107,10 +107,22 @@ const postBody = {
   events: [finalEvent]
 }; 
 
-sendHttpRequest(HTTP_ENDPOINT, (statusCode, headers, body) => {
+sendHttpRequest(
+  HTTP_ENDPOINT, {
+    headers: {
+      'content-type': 'application/json'
+    },
+    method: 'POST',
+    timeout: 5000
+  },
+  JSON.stringify(postBody)
+).then((result) => {
+  const statusCode = result.statusCode;
   if (statusCode >= 400) {
-    data.gtmOnFailure();
-  } else {
-    data.gtmOnSuccess();
+    return data.gtmOnFailure();
   }
-}, {headers: {'content-type': 'application/json'}, method: 'POST', timeout: 5000}, JSON.stringify(postBody));
+  return data.gtmOnSuccess();
+}, (rejectedValue) => {
+  logAmplitude('Request failed with ' + JSON.stringify(rejectedValue));
+  return data.gtmOnFailure();
+});

--- a/template.tpl
+++ b/template.tpl
@@ -274,7 +274,7 @@ const GA4_USER_PREFIX = 'x-ga-mp2-user_properties.';
 const LOG_PREFIX = '[Amplitude] ';
 
 const apiKey = data.apiKey;
-const userIp = data.hideIp ? '$remote' : getRemoteAddress();
+const userIp = data.hideIp ? '$remote' : (getEventData('ip_override') || getRemoteAddress());
 const userId = getEventData('user_id') || getEventData(GA4_USER_PREFIX + 'user_id') || undefined;
 const deviceId = getEventData('client_id');
 const sessionId = makeInteger(getEventData('ga_session_id') + '000');

--- a/template.tpl
+++ b/template.tpl
@@ -367,13 +367,25 @@ const postBody = {
   events: [finalEvent]
 }; 
 
-sendHttpRequest(HTTP_ENDPOINT, (statusCode, headers, body) => {
+sendHttpRequest(
+  HTTP_ENDPOINT, {
+    headers: {
+      'content-type': 'application/json'
+    },
+    method: 'POST',
+    timeout: 5000
+  },
+  JSON.stringify(postBody)
+).then((result) => {
+  const statusCode = result.statusCode;
   if (statusCode >= 400) {
-    data.gtmOnFailure();
-  } else {
-    data.gtmOnSuccess();
+    return data.gtmOnFailure();
   }
-}, {headers: {'content-type': 'application/json'}, method: 'POST', timeout: 5000}, JSON.stringify(postBody));
+  return data.gtmOnSuccess();
+}, (rejectedValue) => {
+  logAmplitude('Request failed with ' + JSON.stringify(rejectedValue));
+  return data.gtmOnFailure();
+});
 
 
 ___SERVER_PERMISSIONS___

--- a/template.tpl
+++ b/template.tpl
@@ -382,8 +382,8 @@ sendHttpRequest(
     return data.gtmOnFailure();
   }
   return data.gtmOnSuccess();
-}, (rejectedValue) => {
-  logAmplitude('Request failed with ' + JSON.stringify(rejectedValue));
+}).catch((error) => {
+  logAmplitude('Request failed with ' + JSON.stringify(error));
   return data.gtmOnFailure();
 });
 


### PR DESCRIPTION
We noticed that the Amplitude Server GTM Template currently does always retrieve the ip address from the request headers via getRemoteAddress (https://developers.google.com/tag-platform/tag-manager/server-side/api?hl=de#getremoteaddress). This works well in most cases but in case of server side requests the forwarded or x-forwarded-for headers might be missing while the ip address is set in the standard "ip_override" event data payload.

I adjusted the code to priotize "ip_override" if set to support both ip address overrides and proper passing of the ip in server side requests.

Additionally I added an update to save the ssgtm from crashlooping. The outage from sunday (12.04.2026 https://status.amplitude.com/incidents/zlktj3t0441x) caused the EU endpoint not responding anymore. This was not properly catched from the template. In general it seems to be a not well known bug from google that this can actually crash the whole sgtm but they recommend using sendHttpRequest like this with the .then notation: https://developers.google.com/tag-platform/tag-manager/server-side/api?hl=de#sendHttpRequest

I updated this so the template should not be able to cause ssGTM crashes anymore because of this.

Regards
Florian