### PR TITLE
Add example app for local end-to-end testing of the template

### DIFF
--- a/example-app/.env.example
+++ b/example-app/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env (gitignored) and fill in your own value.
+#
+# CONTAINER_CONFIG identifies YOUR server GTM container — get it from the GTM
+# UI: open your server container → Admin → Container Settings, or the manual
+# provisioning instructions (it's the base64 "Container Config" string).
+# It decodes to something like: id=GTM-XXXXXXX&env=1&auth=…
+CONTAINER_CONFIG=

--- a/example-app/.gitignore
+++ b/example-app/.gitignore
@@ -1,0 +1,5 @@
+# Local TLS certs are generated per-machine with mkcert (see README) — never commit them
+certs/
+
+# Holds your GTM container's CONTAINER_CONFIG (see .env.example) — never commit it
+.env

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -2,11 +2,11 @@
 
 A minimal setup for testing this repo's Amplitude tag template locally:
 
-- `**docker-compose.yml**` — runs Google's official server-side GTM image as a
-tagging server on `localhost:8080` and a debug/preview server on
-`localhost:8081` (both loaded with container `GTM-XXXXXXX`), plus a small
-Caddy sidecar (`preview-tls`) that TLS-fronts the preview server so the
-tagging server can forward preview hits to it.
+- **`docker-compose.yml`** — runs Google's official server-side GTM image as a
+  tagging server on `localhost:8080` and a debug/preview server on
+  `localhost:8081` (both loaded with container `GTM-XXXXXXX`), plus a small
+  Caddy sidecar (`preview-tls`) that TLS-fronts the preview server so the
+  tagging server can forward preview hits to it.
 - `**index.html` / `server.js**` — a one-page app on `https://localhost:3000`
 with buttons that fire GA4-format hits (`page_view`, `sign_up`, `purchase`,
 `button_click`) at the tagging server's `/g/collect` endpoint. The GA4 client

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -140,11 +140,12 @@ Amplitude tag shows up in preview), and a hit without it exercises the
 ## Run it
 
 ```sh
+cd example-app
+
 # 0. One-time: generate the local TLS cert. The certs/ directory is
 #    gitignored — every machine generates its own.
 #    Install mkcert first if needed: brew install mkcert && mkcert -install
 mkdir -p certs
-mkcert -cert-file certs/localhost.pem -key-file certs/localhost-key.pem localhost 127.0.0.1
 
 # 1. One-time: point the stack at YOUR server GTM container. Copy the
 #    example env file and set CONTAINER_CONFIG (the base64 string from the

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -1,0 +1,187 @@
+# Example app — Amplitude server-side GTM template
+
+A minimal setup for testing this repo's Amplitude tag template locally:
+
+- `**docker-compose.yml**` — runs Google's official server-side GTM image as a
+tagging server on `localhost:8080` and a debug/preview server on
+`localhost:8081` (both loaded with container `GTM-XXXXXXX`), plus a small
+Caddy sidecar (`preview-tls`) that TLS-fronts the preview server so the
+tagging server can forward preview hits to it.
+- `**index.html` / `server.js**` — a one-page app on `https://localhost:3000`
+with buttons that fire GA4-format hits (`page_view`, `sign_up`, `purchase`,
+`button_click`) at the tagging server's `/g/collect` endpoint. The GA4 client
+in the container claims them and hands the event data to the Amplitude tag.
+The same server also proxies Tag Assistant's debug traffic (see the preview
+section below).
+
+## How server-side GTM works (vs client-side)
+
+In **client-side GTM** the container runs in the browser and each vendor tag
+calls that vendor's JS SDK, so the browser talks to every vendor directly. In
+**server-side GTM** the browser sends **one** stream of events to a container
+running on a server you host, and tags there fan events out to vendors via
+plain server-to-server HTTP calls — no SDKs involved.
+
+```
+┌────── Browser ──────┐        ┌───── Your server (the Docker container, :8080) ─────┐
+│                     │        │        sGTM container  GTM-XXXXXXX                   │
+│  user clicks        │        │                                                      │
+│    │                │  one   │  ① CLIENT (new concept — no equivalent in web GTM)   │
+│    ▼                │  HTTP  │     The GA4 Client listens for /g/collect requests,  │
+│  gtag.js  ──────────┼───────►│     "claims" them, parses the raw hit into a clean   │
+│  (GA4 format hit)   │  hit   │     Event Data object (event_name, client_id, …)     │
+│                     │        │        │                                             │
+└─────────────────────┘        │        ▼                                             │
+                               │  ② TRIGGER fires        (same idea as web GTM)       │
+                               │        │                                             │
+                               │        ▼                                             │
+                               │  ③ TAG: Amplitude template (this repo)               │
+                               │     source.js reads Event Data, builds a JSON        │
+                               │     payload, and POSTs it server-to-server ──────────┼──► api2.amplitude.com/2/httpapi
+                               └──────────────────────────────────────────────────────┘
+```
+
+Two things are genuinely new compared to web GTM:
+
+1. **Clients.** A server has no dataLayer — it only receives raw HTTP
+  requests. A *Client* is the adapter that recognizes an incoming request
+   format ("this is a GA4 hit") and converts it into the Event Data object
+   that triggers and tags consume. That's why this app's hits are GA4-shaped:
+   so the built-in GA4 Client claims them.
+2. **Tags make HTTP calls, not SDK calls.** There is no Amplitude SDK on the
+  server. This repo's `source.js` *is* the tag: it pulls `event_name`,
+   `client_id`, `user_id` etc. out of Event Data and calls `sendHttpRequest`
+   against Amplitude's HTTP V2 API. The template replaces the SDK.
+
+### How this example app maps onto that
+
+```
+index.html (localhost:3000)          server.js              Docker "tagging" (:8080)
+┌─────────────────────────┐      ┌──────────────┐      ┌───────────────────────────┐
+│ button click            │      │ proxy        │      │ GA4 Client claims hit     │
+│  └► fetch('/g/collect   │ ───► │ /g/collect ─►│ ───► │  └► Event Data            │
+│      ?en=sign_up        │      │ (CORS dodge  │      │      └► trigger           │
+│      &cid=…&uid=…')     │      │  only)       │      │          └► Amplitude tag ─┼──► Amplitude
+└─────────────────────────┘      └──────────────┘      └───────────────────────────┘
+     plays the role of                plumbing               plays the role of
+     gtag.js on a real site                                  your deployed sGTM server
+```
+
+- `index.html` fakes what `gtag.js` does on a real site: build a GA4-format
+hit (`en=` event name, `cid=` client id, `uid=` user id) and send it. On a
+production site you'd configure gtag.js with `server_container_url`
+pointing at your sGTM domain and it does this for you.
+- `server.js` is not part of the GTM story at all — it terminates TLS (mkcert
+cert in `certs/`), proxies `/g/collect` because browsers block the
+cross-origin call (`/g/collect` responses carry no CORS headers), and
+proxies `/gtm/*` so Tag Assistant preview works (next section).
+- The Docker `tagging` container is a real sGTM server, loaded with container
+`GTM-XXXXXXX`, running whatever Clients/triggers/tags that container
+version configures — including the Amplitude tag built from this template.
+
+The analogy to hold onto: **trigger → tag is identical to web GTM; the "SDK
+call" is replaced by a server-side HTTP request the template constructs; and
+Clients are the new front door that turns raw HTTP traffic into events.**
+
+### How preview (Tag Assistant) works locally
+
+Preview involves a second sGTM server: the **preview server** runs your
+*draft workspace* in debug mode and streams results to Tag Assistant, while
+the tagging server keeps serving the *published* version. Two constraints
+shape the local setup:
+
+1. The GTM UI's **Preview** button opens `{server URL}/gtm/debug?…` — and this
+  container's server URL is set to `https://localhost:3000`. So our app
+   server must answer `/gtm/`* over HTTPS and hand it to the preview server.
+2. Hits are *never* sent to the preview server directly (it 404s them).
+  Instead the **tagging server** inspects every hit: if it carries an
+   `X-Gtm-Server-Preview` header, it forwards the hit to its configured
+   `PREVIEW_SERVER_URL` — which the image insists must be `https://`. The
+   preview container only speaks plain HTTP, hence the Caddy TLS sidecar.
+
+```
+┌───────────────────────────── Browser ─────────────────────────────┐
+│  Tag Assistant tab                 example app page               │
+│  (opened by GTM UI “Preview”,      (paste the preview token from  │
+│   loads /gtm/debug?…)               ⋮ → “Send requests manually”) │
+└──────┬──────────────────────────────────┬─────────────────────────┘
+       │ /gtm/*                           │ /g/collect
+       │                                  │ (+ X-Gtm-Server-Preview header
+       ▼                                  ▼  when the token box is filled)
+┌── server.js — https://localhost:3000 (mkcert TLS) ────────────────┐
+│      /gtm/* ──────────────────┐        /g/collect ────────┐       │
+└───────────────────────────────┼───────────────────────────┼───────┘
+                                │                           ▼
+                                │        ┌─ tagging server (:8080) ──────────────┐
+                                │        │ runs the PUBLISHED container version  │
+                                │        │                                       │
+                                │        │ no preview header:                    │
+                                │        │   process here ──► api2.amplitude.com │
+                                │        │                                       │
+                                │        │ preview header present:               │
+                                │        │   forward hit to PREVIEW_SERVER_URL ──┼──┐
+                                │        └───────────────────────────────────────┘  │
+                                │                                                   │
+                                │            ┌─ preview-tls (Caddy, https──►http) ◄─┘
+                                │            └──────────────┬──────────────────────
+                                ▼                           ▼
+                       ┌─ preview server (:8081) ─────────────────────────────────┐
+                       │ runs your DRAFT workspace in debug mode:                 │
+                       │  • executes the hit (clients → triggers → tags,          │
+                       │    real outbound calls included ──► api2.amplitude.com)  │
+                       │  • streams what happened back to the Tag Assistant tab   │
+                       └──────────────────────────────────────────────────────────┘
+```
+
+So a hit with the token exercises your **draft** (that's why an unpublished
+Amplitude tag shows up in preview), and a hit without it exercises the
+**published** version — if the two behave differently, you haven't published.
+
+## Run it
+
+```sh
+# 0. One-time: generate the local TLS cert. The certs/ directory is
+#    gitignored — every machine generates its own.
+#    Install mkcert first if needed: brew install mkcert && mkcert -install
+mkdir -p certs
+mkcert -cert-file certs/localhost.pem -key-file certs/localhost-key.pem localhost 127.0.0.1
+
+# 1. One-time: point the stack at YOUR server GTM container. Copy the
+#    example env file and set CONTAINER_CONFIG (the base64 string from the
+#    GTM UI's manual provisioning instructions). .env is gitignored.
+cp .env.example .env
+
+# 2. Start the sGTM servers (Docker must be running)
+docker compose up -d
+
+# 3. Start the example app
+node server.js
+
+# 4. Open https://localhost:3000 and click the buttons   (note: httpS)
+```
+
+## Debugging in Tag Assistant
+
+Requires the container's server URL (GTM UI → Admin → Container Settings) to
+be `https://localhost:3000`.
+
+1. In the GTM UI for `GTM-XXXXXXX`, click **Preview** — Tag Assistant loads
+   via the `/gtm/debug` proxy.
+2. In Tag Assistant, open **⋮ → Send requests manually** and copy the
+   `X-Gtm-Server-Preview` header value.
+3. Paste it into the "Preview token" box on `https://localhost:3000` and click
+   the event buttons — each hit appears in Tag Assistant, showing the claiming
+   client, matched triggers, and the tag's outgoing request/response to
+   Amplitude.
+
+Tokens are session-bound: if you reopen Tag Assistant, copy a fresh one. To
+watch raw traffic instead: `docker compose logs -f tagging`.
+
+## Notes
+
+- `CONTAINER_CONFIG` (set in `.env`, read by the compose file) decodes to
+`id=GTM-XXXXXXX&env=1&auth=…` — it pins the servers to your container
+environment. It contains an auth token, which is why `.env` is gitignored.
+- For a real deployment, run the same image on an approved cloud (GCP Cloud
+Run / App Engine, AWS, or Azure) per Google's sGTM provisioning docs.
+

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -158,7 +158,7 @@ docker compose up -d
 # 3. Start the example app
 node server.js
 
-# 4. Open https://localhost:3000 and click the buttons   (note: httpS)
+# 4. Open https://localhost:3000 and click the buttons   (note: HTTPS)
 ```
 
 ## Debugging in Tag Assistant

--- a/example-app/docker-compose.yml
+++ b/example-app/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  # Debug/preview server — pair with Tag Assistant preview in the GTM UI
+  preview:
+    image: gcr.io/cloud-tagging-10302018/gtm-cloud-image:stable
+    platform: linux/amd64
+    environment:
+      CONTAINER_CONFIG: ${CONTAINER_CONFIG:?set CONTAINER_CONFIG in example-app/.env — see .env.example}
+      RUN_AS_PREVIEW_SERVER: "true"
+    ports:
+      - "8081:8080"
+
+  # The tagging server insists PREVIEW_SERVER_URL is https://, but the preview
+  # server only speaks plain HTTP — this Caddy sidecar terminates TLS in front
+  # of it (self-signed internal cert, hence NODE_TLS_REJECT_UNAUTHORIZED below)
+  preview-tls:
+    image: caddy:2
+    command: caddy reverse-proxy --from https://preview-tls --to http://preview:8080 --internal-certs
+    depends_on:
+      - preview
+
+  # Tagging server — receives events from the example app; forwards hits that
+  # carry the X-Gtm-Server-Preview header to the preview server for debugging
+  tagging:
+    image: gcr.io/cloud-tagging-10302018/gtm-cloud-image:stable
+    platform: linux/amd64
+    environment:
+      CONTAINER_CONFIG: ${CONTAINER_CONFIG:?set CONTAINER_CONFIG in example-app/.env — see .env.example}
+      PREVIEW_SERVER_URL: https://preview-tls
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - preview-tls

--- a/example-app/index.html
+++ b/example-app/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Amplitude sGTM Example App</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 640px; margin: 3rem auto; padding: 0 1rem; color: #1a1a2e; }
+    h1 { font-size: 1.4rem; }
+    button { display: block; width: 100%; margin: .5rem 0; padding: .75rem 1rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 8px; background: #f7f7fb; cursor: pointer; text-align: left; }
+    button:hover { background: #ececf5; }
+    #log { margin-top: 1.5rem; padding: 1rem; background: #0f1117; color: #9fe8a8; border-radius: 8px; font-family: ui-monospace, monospace; font-size: .8rem; white-space: pre-wrap; min-height: 6rem; }
+  </style>
+</head>
+<body>
+  <h1>Amplitude server-side GTM example</h1>
+  <p>Each button sends a GA4-format hit to <code>/g/collect</code>, which this
+     app's server proxies to the local sGTM tagging server on port 8080, where
+     the GA4 client claims it and the Amplitude tag can forward it.</p>
+
+  <p><label>Preview token (Tag Assistant → ⋮ → “Send requests manually” → <code>X-Gtm-Server-Preview</code> value):<br>
+     <input id="previewToken" style="width:100%;padding:.4rem" placeholder="paste token to debug hits in Tag Assistant"
+            oninput="localStorage.previewToken = this.value"></label></p>
+
+  <button onclick="sendEvent('page_view')">Send page_view</button>
+  <button onclick="sendEvent('sign_up', { 'ep.method': 'email' })">Send sign_up</button>
+  <button onclick="sendEvent('purchase', { 'ep.currency': 'USD', 'epn.value': '29.99', 'ep.item_name': 'Pro Plan' })">Send purchase</button>
+  <button onclick="sendEvent('button_click', { 'ep.button_id': 'cta_hero' })">Send button_click</button>
+
+  <div id="log">Waiting for events…</div>
+
+  <script>
+    const SGTM_URL = ''; // same-origin; server.js proxies /g/collect to the sGTM tagging server
+    const MEASUREMENT_ID = 'G-EXAMPLE1'; // placeholder; the sGTM GA4 client only needs the shape
+
+    // Stable client_id + session_id, like gtag.js would maintain
+    document.getElementById('previewToken').value = localStorage.previewToken || '';
+
+    const clientId = localStorage.cid || (localStorage.cid = Math.random().toString(36).slice(2) + '.' + Math.floor(Date.now() / 1000));
+    const sessionId = sessionStorage.sid || (sessionStorage.sid = String(Math.floor(Date.now() / 1000)));
+
+    async function sendEvent(name, extra = {}) {
+      const params = new URLSearchParams({
+        v: '2',
+        tid: MEASUREMENT_ID,
+        cid: clientId,
+        sid: sessionId,
+        en: name,
+        dl: location.href,
+        dt: document.title,
+        uid: 'example-user-1',
+        _et: '100',
+        ...extra,
+      });
+      const url = SGTM_URL + '/g/collect?' + params;
+      const line = (msg) => {
+        const log = document.getElementById('log');
+        log.textContent = new Date().toLocaleTimeString() + '  ' + msg + '\n' + log.textContent;
+      };
+      try {
+        const token = document.getElementById('previewToken').value.trim();
+        const headers = token ? { 'X-Gtm-Server-Preview': token } : {};
+        const res = await fetch(url, { method: 'POST', headers });
+        line(name + (token ? ' [preview]' : '') + ' → HTTP ' + res.status);
+      } catch (e) {
+        line(name + ' → FAILED (' + e.message + ') — is the tagging server up?');
+      }
+    }
+
+    sendEvent('page_view');
+  </script>
+</body>
+</html>

--- a/example-app/server.js
+++ b/example-app/server.js
@@ -1,0 +1,64 @@
+const https = require('https');
+const http = require('http');
+const net = require('net');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const TAGGING_URL = 'http://localhost:8080'; // sGTM tagging server
+const PREVIEW_URL = 'http://localhost:8081'; // sGTM debug/preview server
+
+const tls = {
+  key: fs.readFileSync(path.join(__dirname, 'certs', 'localhost-key.pem')),
+  cert: fs.readFileSync(path.join(__dirname, 'certs', 'localhost.pem')),
+};
+
+const proxyTo = (base, req, res) => {
+  const proxyReq = http.request(base + req.url, {
+    method: req.method,
+    headers: { ...req.headers, host: 'localhost' },
+  }, (proxyRes) => {
+    res.writeHead(proxyRes.statusCode, proxyRes.headers);
+    proxyRes.pipe(res);
+  });
+  proxyReq.on('error', (e) => {
+    res.writeHead(502, { 'Content-Type': 'text/plain' });
+    res.end('sGTM unreachable: ' + e.message);
+  });
+  req.pipe(proxyReq);
+};
+
+const server = https.createServer(tls, (req, res) => {
+  // Tag Assistant debug endpoints live under /gtm/ and must reach the
+  // preview server. Hits always go to the tagging server — it forwards ones
+  // carrying the X-Gtm-Server-Preview header to the preview server itself.
+  if (req.url.startsWith('/gtm/')) return proxyTo(PREVIEW_URL, req, res);
+  if (req.url.startsWith('/g/collect')) return proxyTo(TAGGING_URL, req, res);
+
+  const html = fs.readFileSync(path.join(__dirname, 'index.html'));
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+  res.end(html);
+});
+
+// Pass websocket upgrades (used by the Tag Assistant debug UI) through to
+// the preview server as a raw TCP pipe.
+server.on('upgrade', (req, socket, head) => {
+  const upstream = net.connect(8081, 'localhost', () => {
+    let raw = `${req.method} ${req.url} HTTP/1.1\r\n`;
+    for (let i = 0; i < req.rawHeaders.length; i += 2) {
+      raw += `${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}\r\n`;
+    }
+    upstream.write(raw + '\r\n');
+    if (head && head.length) upstream.write(head);
+    socket.pipe(upstream);
+    upstream.pipe(socket);
+  });
+  upstream.on('error', () => socket.destroy());
+  socket.on('error', () => upstream.destroy());
+});
+
+server.listen(PORT, () => {
+  console.log(`Example app running at https://localhost:${PORT}`);
+  console.log(`  /gtm/*      → ${PREVIEW_URL} (Tag Assistant debug)`);
+  console.log(`  /g/collect  → ${TAGGING_URL} (or preview server when the preview header is set)`);
+});


### PR DESCRIPTION
Adds `example-app/` — a self-contained local environment for testing this template end-to-end.

Linear: [SDKW-31](https://linear.app/amplitude/issue/SDKW-31/review-server-side-gtm-customers-pr)

## What's included

- **`docker-compose.yml`** — Google's official sGTM image as a tagging server (`:8080`) and debug/preview server (`:8081`), plus a Caddy TLS sidecar: the image requires `PREVIEW_SERVER_URL` to be `https://`, so the sidecar terminates TLS in front of the plain-HTTP preview server to make Tag Assistant preview work locally.
- **`index.html` / `server.js`** — a one-page app on `https://localhost:3000` with buttons that fire GA4-format hits (`page_view`, `sign_up`, `purchase`, `button_click`). The server terminates TLS (mkcert), proxies `/g/collect` to the tagging server (the sGTM endpoint sends no CORS headers, so browsers can't call it cross-origin), and proxies `/gtm/*` to the preview server so the GTM UI's Preview button works against `https://localhost:3000`.
- **`README.md`** — explains server-side GTM vs client-side GTM (Clients, triggers, tags-as-HTTP-calls) and how the preview/debug flow is wired, with diagrams.

## Notes

- TLS certs are **not** committed: `example-app/certs/` is gitignored and the README covers generating them per-machine with mkcert.
- Verified end-to-end locally: hits are claimed by the GA4 client, appear in Tag Assistant preview (draft workspace), and the Amplitude tag's outgoing request to `api2.amplitude.com/2/httpapi` is visible there.
<img width="844" height="791" alt="Screenshot 2026-07-07 at 3 18 11 PM" src="https://github.com/user-attachments/assets/ca7b7469-e25c-4830-a51d-97724f66a529" />
<img width="2063" height="652" alt="Screenshot 2026-07-07 at 3 18 25 PM" src="https://github.com/user-attachments/assets/68ea8afa-5287-438b-b19f-9bcd0b9b7509" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)